### PR TITLE
Fix for iOS Safari bug no labels

### DIFF
--- a/js/PickerItem.js
+++ b/js/PickerItem.js
@@ -21,5 +21,9 @@ type Props = {
 const Option = (props: any) => createElement('option', props);
 
 export default function PickerItem({color, label, testID, value}: Props) {
-  return <Option style={{color}} testID={testID} value={value} label={label} />;
+  return (
+    <Option style={{color}} testID={testID} value={value} label={label}>
+      {label}
+    </Option>
+  );
 }


### PR DESCRIPTION
The labels in Safari iOS are not displayed. The reason is that in PickerItem.js (line 23) the Option component is adding the label prop but unfortunately Safari iOS doesn't render the label. It appears to need the textContent of the option to properly render the label.

So by adding the label as textContent the Safari case gets solved as well as for other browsers that don't support the label property.

 <Option style={{color}} testID={testID} value={value} label={label}>
      {label}
    </Option>
The label is still passed as prop since the label values would default to textContent
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#Browser_compatibility